### PR TITLE
Update inspect.lisp for more SBCL internal changes

### DIFF
--- a/inspect.lisp
+++ b/inspect.lisp
@@ -762,14 +762,13 @@ cons cells and LIST-TYPE is :normal, :dotted, or :cyclic"
 
 (defun inspected-structure-parts (object)
   (let ((components-list '())
-        #+sbcl (info (sb-kernel:layout-info (sb-kernel:layout-of object))))
-    #+sbcl
+        #+sbcl (info (sb-kernel:wrapper-info (sb-kernel:wrapper-of object))))
+    #+sbcl 
     (when (sb-kernel::defstruct-description-p info)
-      (dolist (dd-slot (sb-kernel:dd-slots info))
+      (dolist (dd-slot (sb-kernel:dd-slots info) (nreverse components-list))
         (push (cons (string (sb-kernel:dsd-name dd-slot))
                     (funcall (sb-kernel:dsd-accessor-name dd-slot) object))
-              components-list)))
-    (nreverse components-list)))
+              components-list)))))
 
 (defmethod inspected-parts ((object structure-object))
   (let ((components (inspected-structure-parts object)))


### PR DESCRIPTION
This fixes #3 I pulled the code from SBCL's included sb-aclrepl which still shares a close lineage.

```
$ sbcl
This is SBCL 2.1.6, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
* (ql:quickload "prepl")
To load "prepl":
  Load 1 ASDF system:
    prepl
; Loading "prepl"

("prepl")
* (prepl:repl)
Portable REPL on SBCL, main thread.  Type :help for help.
CL-USER> (defstruct foo x y)
FOO
CL-USER> :in (make-foo :x 123 :y 456)

#<STRUCTURE-CLASS COMMON-LISP-USER::FOO> at #x0000001001B41EA0
   0 X --------------> fixnum 123
   1 Y --------------> fixnum 456
[1i] CL-USER> 
```